### PR TITLE
Add tooltip and fix typos/indentations

### DIFF
--- a/404.html
+++ b/404.html
@@ -71,7 +71,7 @@
 
     <body>
 
-        <h1>Uh oh!</h1>
+        <h1>Uh-oh!</h1>
         <p>It seems that you have</p>
         <img src="assets/branding/discovered.png" alt="discovered" class="center"> 
         <p>...a dead end.</p>

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The DiscoverSUTD 2020 Organizing Committee:
 2. **Chua Jia Wei**
 3. [James Raphael Tiovalen](https://github.com/jamestiotio)
 4. [Kenneth Chin Choon Hean](https://github.com/UrFriendKen)
-5. Maryann Seah
+5. Seah Shien Maryann
 6. [Shoham Chakraborty](https://github.com/shohamc1)
 
 With immense support from Jia Xin of the SUTD Office of Student Life.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,6 @@ Our gratitude to these stakeholders as well:
 - All of the Fifth Rows & Interest Groups in SUTD
 - All of the Laboratories & Research Groups in SUTD
 - All of the different SUTD Pillars & Departments
-- [All of the stakeholders involved in the SUTD Human Library 2020](people.html)
+- [All of the stakeholders involved in the SUTD Human Library 2020](https://discover.opensutd.org/people.html)
 - The DiscoverSUTD 2019 Planning Team
 - OpenSUTD

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -12,58 +12,58 @@ tfoot, thead, tr, th, td, article, aside,
 canvas, details, embed, figure, figcaption,
 footer, header, hgroup, menu, nav, output, ruby,
 section, summary, time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;}
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;}
 
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
-	display: block;}
+    display: block;}
 
 body {
-	line-height: 1;
+    line-height: 1;
 }
 
 ol, ul {
-	list-style: none;
+    list-style: none;
 }
 
 blockquote, q {
-	quotes: none;
+    quotes: none;
 }
 
-	blockquote:before, blockquote:after, q:before, q:after {
-		content: '';
-		content: none;
-	}
+    blockquote:before, blockquote:after, q:before, q:after {
+        content: '';
+        content: none;
+    }
 
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+    border-collapse: collapse;
+    border-spacing: 0;
 }
 
 body {
-	-webkit-text-size-adjust: none;
+    -webkit-text-size-adjust: none;
 }
 
 mark {
-	background-color: transparent;
-	color: inherit;
+    background-color: transparent;
+    color: inherit;
 }
 
 input::-moz-focus-inner {
-	border: 0;
-	padding: 0;
+    border: 0;
+    padding: 0;
 }
 
 input, select, textarea {
-	-moz-appearance: none;
-	-webkit-appearance: none;
-	-ms-appearance: none;
-	appearance: none;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
 }
 
 .center {
@@ -75,562 +75,568 @@ input, select, textarea {
 
 /* Basic */
 
-	html {
-		box-sizing: border-box;
-	}
+    html {
+        box-sizing: border-box;
+    }
 
-	*, *:before, *:after {
-		box-sizing: inherit;
-	}
+    *, *:before, *:after {
+        box-sizing: inherit;
+    }
 
-	body {
-		background: #fff;
-		overflow: hidden;
-	}
+    body {
+        background: #fff;
+        overflow: hidden;
+    }
 
-		body.is-preload *, body.is-preload *:before, body.is-preload *:after {
-			-moz-animation: none !important;
-			-webkit-animation: none !important;
-			-ms-animation: none !important;
-			animation: none !important;
-			-moz-transition: none !important;
-			-webkit-transition: none !important;
-			-ms-transition: none !important;
-			transition: none !important;
-		}
+        body.is-preload *, body.is-preload *:before, body.is-preload *:after {
+            -moz-animation: none !important;
+            -webkit-animation: none !important;
+            -ms-animation: none !important;
+            animation: none !important;
+            -moz-transition: none !important;
+            -webkit-transition: none !important;
+            -ms-transition: none !important;
+            transition: none !important;
+        }
 
-	body, input, select, textarea {
-		color: #800000;
-		font-family: 'Source Sans Pro', sans-serif;
-		font-size: 15pt;
-		font-weight: 300 !important;
-		letter-spacing: -0.025em;
-		line-height: 1.75em;
-	}
+    body, input, select, textarea {
+        color: #800000;
+        font-family: 'Source Sans Pro', sans-serif;
+        font-size: 15pt;
+        font-weight: 300 !important;
+        letter-spacing: -0.025em;
+        line-height: 1.75em;
+    }
 
-	a {
-		-moz-transition: border-color 0.2s ease-in-out;
-		-webkit-transition: border-color 0.2s ease-in-out;
-		-ms-transition: border-color 0.2s ease-in-out;
-		transition: border-color 0.2s ease-in-out;
-		border-bottom: dotted 1px;
-		color: inherit;
-		outline: 0;
-		text-decoration: none;
-	}
+    a {
+        -moz-transition: border-color 0.2s ease-in-out;
+        -webkit-transition: border-color 0.2s ease-in-out;
+        -ms-transition: border-color 0.2s ease-in-out;
+        transition: border-color 0.2s ease-in-out;
+        border-bottom: dotted 1px;
+        color: inherit;
+        outline: 0;
+        text-decoration: none;
+    }
 
-		a:hover {
-			border-color: transparent;
-		}
+        a:hover {
+            border-color: transparent;
+        }
 
 /* Icon */
 
-	.icon {
-		text-decoration: none;
-		position: relative;
-	}
+    .icon {
+        text-decoration: none;
+        position: relative;
+    }
 
-		.icon:before {
-			-moz-osx-font-smoothing: grayscale;
-			-webkit-font-smoothing: antialiased;
-			display: inline-block;
-			font-style: normal;
-			font-variant: normal;
-			text-rendering: auto;
-			line-height: 1;
-			text-transform: none !important;
-			font-family: 'Font Awesome 5 Pro';
-			font-weight: 400;
-		}
+        .icon:before {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: inline-block;
+            font-style: normal;
+            font-variant: normal;
+            text-rendering: auto;
+            line-height: 1;
+            text-transform: none !important;
+            font-family: 'Font Awesome 5 Pro';
+            font-weight: 400;
+        }
 
-		.icon > .label {
-			display: none;
-		}
+        .icon > .label {
+            display: none;
+        }
 
-		.icon.solid:before {
-			font-weight: 900;
-		}
+        .icon.solid:before {
+            font-weight: 900;
+        }
 
-		.icon.brands:before {
-			font-family: 'Font Awesome 5 Brands';
-		}
+        .icon.brands:before {
+            font-family: 'Font Awesome 5 Brands';
+        }
 
 /* Wrapper */
 
-	@-moz-keyframes wrapper {
-		0% {
-			opacity: 0;
-		}
+    @-moz-keyframes wrapper {
+        0% {
+            opacity: 0;
+        }
 
-		100% {
-			opacity: 1;
-		}
-	}
+        100% {
+            opacity: 1;
+        }
+    }
 
-	@-webkit-keyframes wrapper {
-		0% {
-			opacity: 0;
-		}
+    @-webkit-keyframes wrapper {
+        0% {
+            opacity: 0;
+        }
 
-		100% {
-			opacity: 1;
-		}
-	}
+        100% {
+            opacity: 1;
+        }
+    }
 
-	@-ms-keyframes wrapper {
-		0% {
-			opacity: 0;
-		}
+    @-ms-keyframes wrapper {
+        0% {
+            opacity: 0;
+        }
 
-		100% {
-			opacity: 1;
-		}
-	}
+        100% {
+            opacity: 1;
+        }
+    }
 
-	@keyframes wrapper {
-		0% {
-			opacity: 0;
-		}
+    @keyframes wrapper {
+        0% {
+            opacity: 0;
+        }
 
-		100% {
-			opacity: 1;
-		}
-	}
+        100% {
+            opacity: 1;
+        }
+    }
 
-	#wrapper {
-		-moz-animation: wrapper 1s forwards;
-		-webkit-animation: wrapper 1s forwards;
-		-ms-animation: wrapper 1s forwards;
-		animation: wrapper 1s forwards;
-		height: 100%;
-		left: 0;
-		opacity: 0;
-		position: fixed;
-		top: 0;
-		width: 100%;
-	}
+    #wrapper {
+        -moz-animation: wrapper 1s forwards;
+        -webkit-animation: wrapper 1s forwards;
+        -ms-animation: wrapper 1s forwards;
+        animation: wrapper 1s forwards;
+        height: 100%;
+        left: 0;
+        opacity: 0;
+        position: fixed;
+        top: 0;
+        width: 100%;
+    }
 
 /* Main */
 
-	#main {
-		height: 100%;
-		left: 0;
-		position: fixed;
-		text-align: center;
-		top: 0;
-		width: 100%;
-	}
+    #main {
+        height: 100%;
+        left: 0;
+        position: fixed;
+        text-align: center;
+        top: 0;
+        width: 100%;
+    }
 
-		#main:before {
-			content: '';
-			display: inline-block;
-			height: 100%;
-			margin-right: 0;
-			vertical-align: middle;
-			width: 1px;
-		}
+        #main:before {
+            content: '';
+            display: inline-block;
+            height: 100%;
+            margin-right: 0;
+            vertical-align: middle;
+            width: 1px;
+        }
 
 /* Header */
 
-	@-moz-keyframes header {
-		0% {
-			-moz-transform: translate3d(0,1em,0);
-			-webkit-transform: translate3d(0,1em,0);
-			-ms-transform: translate3d(0,1em,0);
-			transform: translate3d(0,1em,0);
-			opacity: 0;
-		}
+    @-moz-keyframes header {
+        0% {
+            -moz-transform: translate3d(0,1em,0);
+            -webkit-transform: translate3d(0,1em,0);
+            -ms-transform: translate3d(0,1em,0);
+            transform: translate3d(0,1em,0);
+            opacity: 0;
+        }
 
-		100% {
-			-moz-transform: translate3d(0,0,0);
-			-webkit-transform: translate3d(0,0,0);
-			-ms-transform: translate3d(0,0,0);
-			transform: translate3d(0,0,0);
-			opacity: 1;
-		}
-	}
+        100% {
+            -moz-transform: translate3d(0,0,0);
+            -webkit-transform: translate3d(0,0,0);
+            -ms-transform: translate3d(0,0,0);
+            transform: translate3d(0,0,0);
+            opacity: 1;
+        }
+    }
 
-	@-webkit-keyframes header {
-		0% {
-			-moz-transform: translate3d(0,1em,0);
-			-webkit-transform: translate3d(0,1em,0);
-			-ms-transform: translate3d(0,1em,0);
-			transform: translate3d(0,1em,0);
-			opacity: 0;
-		}
+    @-webkit-keyframes header {
+        0% {
+            -moz-transform: translate3d(0,1em,0);
+            -webkit-transform: translate3d(0,1em,0);
+            -ms-transform: translate3d(0,1em,0);
+            transform: translate3d(0,1em,0);
+            opacity: 0;
+        }
 
-		100% {
-			-moz-transform: translate3d(0,0,0);
-			-webkit-transform: translate3d(0,0,0);
-			-ms-transform: translate3d(0,0,0);
-			transform: translate3d(0,0,0);
-			opacity: 1;
-		}
-	}
+        100% {
+            -moz-transform: translate3d(0,0,0);
+            -webkit-transform: translate3d(0,0,0);
+            -ms-transform: translate3d(0,0,0);
+            transform: translate3d(0,0,0);
+            opacity: 1;
+        }
+    }
 
-	@-ms-keyframes header {
-		0% {
-			-moz-transform: translate3d(0,1em,0);
-			-webkit-transform: translate3d(0,1em,0);
-			-ms-transform: translate3d(0,1em,0);
-			transform: translate3d(0,1em,0);
-			opacity: 0;
-		}
+    @-ms-keyframes header {
+        0% {
+            -moz-transform: translate3d(0,1em,0);
+            -webkit-transform: translate3d(0,1em,0);
+            -ms-transform: translate3d(0,1em,0);
+            transform: translate3d(0,1em,0);
+            opacity: 0;
+        }
 
-		100% {
-			-moz-transform: translate3d(0,0,0);
-			-webkit-transform: translate3d(0,0,0);
-			-ms-transform: translate3d(0,0,0);
-			transform: translate3d(0,0,0);
-			opacity: 1;
-		}
-	}
+        100% {
+            -moz-transform: translate3d(0,0,0);
+            -webkit-transform: translate3d(0,0,0);
+            -ms-transform: translate3d(0,0,0);
+            transform: translate3d(0,0,0);
+            opacity: 1;
+        }
+    }
 
-	@keyframes header {
-		0% {
-			-moz-transform: translate3d(0,1em,0);
-			-webkit-transform: translate3d(0,1em,0);
-			-ms-transform: translate3d(0,1em,0);
-			transform: translate3d(0,1em,0);
-			opacity: 0;
-		}
+    @keyframes header {
+        0% {
+            -moz-transform: translate3d(0,1em,0);
+            -webkit-transform: translate3d(0,1em,0);
+            -ms-transform: translate3d(0,1em,0);
+            transform: translate3d(0,1em,0);
+            opacity: 0;
+        }
 
-		100% {
-			-moz-transform: translate3d(0,0,0);
-			-webkit-transform: translate3d(0,0,0);
-			-ms-transform: translate3d(0,0,0);
-			transform: translate3d(0,0,0);
-			opacity: 1;
-		}
-	}
+        100% {
+            -moz-transform: translate3d(0,0,0);
+            -webkit-transform: translate3d(0,0,0);
+            -ms-transform: translate3d(0,0,0);
+            transform: translate3d(0,0,0);
+            opacity: 1;
+        }
+    }
 
-	@-moz-keyframes nav-icons {
-		0% {
-			-moz-transform: translate3d(0,1em,0);
-			-webkit-transform: translate3d(0,1em,0);
-			-ms-transform: translate3d(0,1em,0);
-			transform: translate3d(0,1em,0);
-			opacity: 0;
-		}
+    @-moz-keyframes nav-icons {
+        0% {
+            -moz-transform: translate3d(0,1em,0);
+            -webkit-transform: translate3d(0,1em,0);
+            -ms-transform: translate3d(0,1em,0);
+            transform: translate3d(0,1em,0);
+            opacity: 0;
+        }
 
-		100% {
-			-moz-transform: translate3d(0,0,0);
-			-webkit-transform: translate3d(0,0,0);
-			-ms-transform: translate3d(0,0,0);
-			transform: translate3d(0,0,0);
-			opacity: 1;
-		}
-	}
+        100% {
+            -moz-transform: translate3d(0,0,0);
+            -webkit-transform: translate3d(0,0,0);
+            -ms-transform: translate3d(0,0,0);
+            transform: translate3d(0,0,0);
+            opacity: 1;
+        }
+    }
 
-	@-webkit-keyframes nav-icons {
-		0% {
-			-moz-transform: translate3d(0,1em,0);
-			-webkit-transform: translate3d(0,1em,0);
-			-ms-transform: translate3d(0,1em,0);
-			transform: translate3d(0,1em,0);
-			opacity: 0;
-		}
+    @-webkit-keyframes nav-icons {
+        0% {
+            -moz-transform: translate3d(0,1em,0);
+            -webkit-transform: translate3d(0,1em,0);
+            -ms-transform: translate3d(0,1em,0);
+            transform: translate3d(0,1em,0);
+            opacity: 0;
+        }
 
-		100% {
-			-moz-transform: translate3d(0,0,0);
-			-webkit-transform: translate3d(0,0,0);
-			-ms-transform: translate3d(0,0,0);
-			transform: translate3d(0,0,0);
-			opacity: 1;
-		}
-	}
+        100% {
+            -moz-transform: translate3d(0,0,0);
+            -webkit-transform: translate3d(0,0,0);
+            -ms-transform: translate3d(0,0,0);
+            transform: translate3d(0,0,0);
+            opacity: 1;
+        }
+    }
 
-	@-ms-keyframes nav-icons {
-		0% {
-			-moz-transform: translate3d(0,1em,0);
-			-webkit-transform: translate3d(0,1em,0);
-			-ms-transform: translate3d(0,1em,0);
-			transform: translate3d(0,1em,0);
-			opacity: 0;
-		}
+    @-ms-keyframes nav-icons {
+        0% {
+            -moz-transform: translate3d(0,1em,0);
+            -webkit-transform: translate3d(0,1em,0);
+            -ms-transform: translate3d(0,1em,0);
+            transform: translate3d(0,1em,0);
+            opacity: 0;
+        }
 
-		100% {
-			-moz-transform: translate3d(0,0,0);
-			-webkit-transform: translate3d(0,0,0);
-			-ms-transform: translate3d(0,0,0);
-			transform: translate3d(0,0,0);
-			opacity: 1;
-		}
-	}
+        100% {
+            -moz-transform: translate3d(0,0,0);
+            -webkit-transform: translate3d(0,0,0);
+            -ms-transform: translate3d(0,0,0);
+            transform: translate3d(0,0,0);
+            opacity: 1;
+        }
+    }
 
-	@keyframes nav-icons {
-		0% {
-			-moz-transform: translate3d(0,1em,0);
-			-webkit-transform: translate3d(0,1em,0);
-			-ms-transform: translate3d(0,1em,0);
-			transform: translate3d(0,1em,0);
-			opacity: 0;
-		}
+    @keyframes nav-icons {
+        0% {
+            -moz-transform: translate3d(0,1em,0);
+            -webkit-transform: translate3d(0,1em,0);
+            -ms-transform: translate3d(0,1em,0);
+            transform: translate3d(0,1em,0);
+            opacity: 0;
+        }
 
-		100% {
-			-moz-transform: translate3d(0,0,0);
-			-webkit-transform: translate3d(0,0,0);
-			-ms-transform: translate3d(0,0,0);
-			transform: translate3d(0,0,0);
-			opacity: 1;
-		}
-	}
+        100% {
+            -moz-transform: translate3d(0,0,0);
+            -webkit-transform: translate3d(0,0,0);
+            -ms-transform: translate3d(0,0,0);
+            transform: translate3d(0,0,0);
+            opacity: 1;
+        }
+    }
 
-	#header {
-		-moz-animation: header 1s 0.5s forwards;
-		-webkit-animation: header 1s 0.5s forwards;
-		-ms-animation: header 1s 0.5s forwards;
-		animation: header 1s 0.5s forwards;
-		-moz-backface-visibility: hidden;
-		-webkit-backface-visibility: hidden;
-		-ms-backface-visibility: hidden;
-		backface-visibility: hidden;
-		-moz-transform: translate3d(0,0,0);
-		-webkit-transform: translate3d(0,0,0);
-		-ms-transform: translate3d(0,0,0);
-		transform: translate3d(0,0,0);
-		cursor: default;
-		display: inline-block;
-		opacity: 0;
-		position: relative;
-		text-align: center;
-		top: -1em;
-		vertical-align: middle;
-		width: 90%;
-	}
+    #header {
+        -moz-animation: header 1s 0.5s forwards;
+        -webkit-animation: header 1s 0.5s forwards;
+        -ms-animation: header 1s 0.5s forwards;
+        animation: header 1s 0.5s forwards;
+        -moz-backface-visibility: hidden;
+        -webkit-backface-visibility: hidden;
+        -ms-backface-visibility: hidden;
+        backface-visibility: hidden;
+        -moz-transform: translate3d(0,0,0);
+        -webkit-transform: translate3d(0,0,0);
+        -ms-transform: translate3d(0,0,0);
+        transform: translate3d(0,0,0);
+        cursor: default;
+        display: inline-block;
+        opacity: 0;
+        position: relative;
+        text-align: center;
+        top: -1em;
+        vertical-align: middle;
+        width: 90%;
+    }
 
-		#header h1 {
-			font-size: 4.35em;
-			font-weight: 900;
-			letter-spacing: -0.035em;
-			line-height: 1em;
-		}
+        #header h1 {
+            font-size: 4.35em;
+            font-weight: 900;
+            letter-spacing: -0.035em;
+            line-height: 1em;
+        }
 
-		#header p {
-			font-size: 1.75em;
+        #header p {
+            font-size: 1.75em;
             font-weight: 600;
-			margin: 0.75em 0 0.25em 0;
-			opacity: 1;
-		}
+            margin: 0.75em 0 0.25em 0;
+            opacity: 1;
+        }
 
-		#header nav {
-			margin: 1.5em 0 0 0;
-		}
+        #header nav {
+            margin: 1.5em 0 0 0;
+        }
 
-			#header nav li {
-				-moz-animation: nav-icons 0.5s ease-in-out forwards;
-				-webkit-animation: nav-icons 0.5s ease-in-out forwards;
-				-ms-animation: nav-icons 0.5s ease-in-out forwards;
-				animation: nav-icons 0.5s ease-in-out forwards;
-				-moz-backface-visibility: hidden;
-				-webkit-backface-visibility: hidden;
-				-ms-backface-visibility: hidden;
-				backface-visibility: hidden;
-				-moz-transform: translate3d(0,0,0);
-				-webkit-transform: translate3d(0,0,0);
-				-ms-transform: translate3d(0,0,0);
-				transform: translate3d(0,0,0);
-				display: inline-block;
-				height: 5.35em;
-				line-height: 5.885em;
-				opacity: 0;
-				position: relative;
-				top: 0;
-				width: 5.35em;
-			}
+            #header nav li {
+                -moz-animation: nav-icons 0.5s ease-in-out forwards;
+                -webkit-animation: nav-icons 0.5s ease-in-out forwards;
+                -ms-animation: nav-icons 0.5s ease-in-out forwards;
+                animation: nav-icons 0.5s ease-in-out forwards;
+                -moz-backface-visibility: hidden;
+                -webkit-backface-visibility: hidden;
+                -ms-backface-visibility: hidden;
+                backface-visibility: hidden;
+                -moz-transform: translate3d(0,0,0);
+                -webkit-transform: translate3d(0,0,0);
+                -ms-transform: translate3d(0,0,0);
+                transform: translate3d(0,0,0);
+                display: inline-block;
+                height: 5.35em;
+                line-height: 5.885em;
+                opacity: 0;
+                position: relative;
+                top: 0;
+                width: 5.35em;
+            }
 
-				#header nav li:nth-child(1) {
-					-moz-animation-delay: 1.2s;
-					-webkit-animation-delay: 1.2s;
-					-ms-animation-delay: 1.2s;
-					animation-delay: 1.2s;
-				}
+                #header nav li:nth-child(1) {
+                    -moz-animation-delay: 1.2s;
+                    -webkit-animation-delay: 1.2s;
+                    -ms-animation-delay: 1.2s;
+                    animation-delay: 1.2s;
+                }
 
-				#header nav li:nth-child(2) {
-					-moz-animation-delay: 1.45s;
-					-webkit-animation-delay: 1.45s;
-					-ms-animation-delay: 1.45s;
-					animation-delay: 1.45s;
-				}
+                #header nav li:nth-child(2) {
+                    -moz-animation-delay: 1.45s;
+                    -webkit-animation-delay: 1.45s;
+                    -ms-animation-delay: 1.45s;
+                    animation-delay: 1.45s;
+                }
 
-				#header nav li:nth-child(3) {
-					-moz-animation-delay: 1.7s;
-					-webkit-animation-delay: 1.7s;
-					-ms-animation-delay: 1.7s;
-					animation-delay: 1.7s;
-				}
+                #header nav li:nth-child(3) {
+                    -moz-animation-delay: 1.7s;
+                    -webkit-animation-delay: 1.7s;
+                    -ms-animation-delay: 1.7s;
+                    animation-delay: 1.7s;
+                }
 
-				#header nav li:nth-child(4) {
-					-moz-animation-delay: 1.95s;
-					-webkit-animation-delay: 1.95s;
-					-ms-animation-delay: 1.95s;
-					animation-delay: 1.95s;
-				}
+                #header nav li:nth-child(4) {
+                    -moz-animation-delay: 1.95s;
+                    -webkit-animation-delay: 1.95s;
+                    -ms-animation-delay: 1.95s;
+                    animation-delay: 1.95s;
+                }
 
-				#header nav li:nth-child(5) {
-					-moz-animation-delay: 2.2s;
-					-webkit-animation-delay: 2.2s;
-					-ms-animation-delay: 2.2s;
-					animation-delay: 2.2s;
-				}
+                #header nav li:nth-child(5) {
+                    -moz-animation-delay: 2.2s;
+                    -webkit-animation-delay: 2.2s;
+                    -ms-animation-delay: 2.2s;
+                    animation-delay: 2.2s;
+                }
 
-				#header nav li:nth-child(6) {
-					-moz-animation-delay: 2.45s;
-					-webkit-animation-delay: 2.45s;
-					-ms-animation-delay: 2.45s;
-					animation-delay: 2.45s;
-				}
+                #header nav li:nth-child(6) {
+                    -moz-animation-delay: 2.45s;
+                    -webkit-animation-delay: 2.45s;
+                    -ms-animation-delay: 2.45s;
+                    animation-delay: 2.45s;
+                }
 
-				#header nav li:nth-child(7) {
-					-moz-animation-delay: 2.7s;
-					-webkit-animation-delay: 2.7s;
-					-ms-animation-delay: 2.7s;
-					animation-delay: 2.7s;
-				}
+                #header nav li:nth-child(7) {
+                    -moz-animation-delay: 2.7s;
+                    -webkit-animation-delay: 2.7s;
+                    -ms-animation-delay: 2.7s;
+                    animation-delay: 2.7s;
+                }
 
-				#header nav li:nth-child(8) {
-					-moz-animation-delay: 2.95s;
-					-webkit-animation-delay: 2.95s;
-					-ms-animation-delay: 2.95s;
-					animation-delay: 2.95s;
-				}
+                #header nav li:nth-child(8) {
+                    -moz-animation-delay: 2.95s;
+                    -webkit-animation-delay: 2.95s;
+                    -ms-animation-delay: 2.95s;
+                    animation-delay: 2.95s;
+                }
 
-				#header nav li:nth-child(9) {
-					-moz-animation-delay: 3.2s;
-					-webkit-animation-delay: 3.2s;
-					-ms-animation-delay: 3.2s;
-					animation-delay: 3.2s;
-				}
+                #header nav li:nth-child(9) {
+                    -moz-animation-delay: 3.2s;
+                    -webkit-animation-delay: 3.2s;
+                    -ms-animation-delay: 3.2s;
+                    animation-delay: 3.2s;
+                }
 
-				#header nav li:nth-child(10) {
-					-moz-animation-delay: 3.45s;
-					-webkit-animation-delay: 3.45s;
-					-ms-animation-delay: 3.45s;
-					animation-delay: 3.45s;
-				}
+                #header nav li:nth-child(10) {
+                    -moz-animation-delay: 3.45s;
+                    -webkit-animation-delay: 3.45s;
+                    -ms-animation-delay: 3.45s;
+                    animation-delay: 3.45s;
+                }
 
-			#header nav a {
-				-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-				-webkit-touch-callout: none;
-				border: 0;
-				display: inline-block;
-			}
+            #header nav a {
+                -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+                -webkit-touch-callout: none;
+                border: 0;
+                display: inline-block;
+            }
 
-				#header nav a:before {
-					-moz-transition: all 0.2s ease-in-out;
-					-webkit-transition: all 0.2s ease-in-out;
-					-ms-transition: all 0.2s ease-in-out;
-					transition: all 0.2s ease-in-out;
-					border-radius: 100%;
-					border: solid 1px #800000;
-					display: block;
-					font-size: 1.75em;
-					height: 2.5em;
-					line-height: 2.5em;
-					position: relative;
-					text-align: center;
-					top: 0;
-					width: 2.5em;
-				}
+                #header nav a:before {
+                    -moz-transition: all 0.2s ease-in-out;
+                    -webkit-transition: all 0.2s ease-in-out;
+                    -ms-transition: all 0.2s ease-in-out;
+                    transition: all 0.2s ease-in-out;
+                    border-radius: 100%;
+                    border: solid 1px #800000;
+                    display: block;
+                    font-size: 1.75em;
+                    height: 2.5em;
+                    line-height: 2.5em;
+                    position: relative;
+                    text-align: center;
+                    top: 0;
+                    width: 2.5em;
+                }
 
-				#header nav a:hover {
-					font-size: 1.1em;
-				}
+                #header nav a:hover {
+                    font-size: 1.1em;
+                }
 
-					#header nav a:hover:before {
-						background-color: rgba(255, 255, 255, 0.175);
-						color: #800000;
-					}
+                    #header nav a:hover:before {
+                        background-color: rgba(255, 255, 255, 0.175);
+                        color: #800000;
+                    }
 
-				#header nav a:active {
-					font-size: 0.95em;
-					background: none;
-				}
+                #header nav a:active {
+                    font-size: 0.95em;
+                    background: none;
+                }
 
-					#header nav a:active:before {
-						background-color: rgba(255, 255, 255, 0.35);
-						color: #800000;
-					}
+                    #header nav a:active:before {
+                        background-color: rgba(255, 255, 255, 0.35);
+                        color: #800000;
+                    }
 
-				#header nav a span {
-					display: none;
-				}
+                #header nav a span {
+                    display: none;
+                }
 
 /* Footer */
 
-	#footer {
-		bottom: 0;
-		cursor: default;
-		height: 6em;
-		left: 0;
-		line-height: 8em;
-		position: absolute;
-		text-align: center;
-		width: 100%;
-	}
+    #footer {
+        bottom: 0;
+        cursor: default;
+        height: 3em;
+        left: 0;
+        line-height: 3em;
+        position: absolute;
+        text-align: center;
+        width: 100%;
+    }
 
 /* Wide */
 
-	@media screen and (max-width: 1680px) {
+    @media screen and (max-width: 1680px) {
 
-		/* Basic */
+        /* Basic */
 
-			body, input, select, textarea {
-				font-size: 13pt;
-			} }
+            body, input, select, textarea {
+                font-size: 13pt;
+            } }
 
 /* Normal */
 
-	@media screen and (max-width: 1280px) {
+    @media screen and (max-width: 1280px) {
 
-		/* Basic */
+        /* Basic */
 
-			body, input, select, textarea {
-				font-size: 12pt;
-			} }
+            body, input, select, textarea {
+                font-size: 12pt;
+            } }
 
 /* Mobile */
 
-	@media screen and (max-width: 736px) {
+    @media screen and (max-width: 736px) {
 
-		/* Basic */
+        /* Basic */
 
-			body {
-				min-width: 320px;
-			}
+            body {
+                min-width: 320px;
+            }
 
-			body, input, select, textarea {
-				font-size: 11pt;
-			}
+            body, input, select, textarea {
+                font-size: 11pt;
+            }
 
-	/* Header */
+    /* Header */
 
-		#header h1 {
-			font-size: 2.5em;
-		}
+        #header h1 {
+            font-size: 2.5em;
+        }
 
-		#header p {
-			font-size: 1em;
-		}
+        #header p {
+            font-size: 1em;
+        }
 
-		#header nav {
-			font-size: 1em;
-		}
+        #header nav {
+            font-size: 1em;
+        }
 
-			#header nav a:hover {
-				font-size: 1em;
-			}
+            #header nav a:hover {
+                font-size: 1em;
+            }
 
-			#header nav a:active {
-				font-size: 1em;
-			} }
+            #header nav a:active {
+                font-size: 1em;
+            } }
 
 /* Mobile (Portrait) */
 
-	@media screen and (max-width: 480px) {
+    @media screen and (max-width: 480px) {
 
-	/* Header */
+        /* Basic */
 
-		#header nav {
-			padding: 0 1em;
-		} }
+            body, input, select, textarea {
+                font-size: 10pt;
+            }
+
+    /* Header */
+
+        #header nav {
+            padding: 0 1em;
+        } }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -35,10 +35,10 @@ blockquote, q {
     quotes: none;
 }
 
-    blockquote:before, blockquote:after, q:before, q:after {
-        content: '';
-        content: none;
-    }
+blockquote:before, blockquote:after, q:before, q:after {
+    content: '';
+    content: none;
+}
 
 table {
     border-collapse: collapse;
@@ -75,568 +75,568 @@ input, select, textarea {
 
 /* Basic */
 
-    html {
-        box-sizing: border-box;
-    }
+html {
+    box-sizing: border-box;
+}
 
-    *, *:before, *:after {
-        box-sizing: inherit;
-    }
+*, *:before, *:after {
+    box-sizing: inherit;
+}
 
-    body {
-        background: #fff;
-        overflow: hidden;
-    }
+body {
+    background: #fff;
+    overflow: hidden;
+}
 
-        body.is-preload *, body.is-preload *:before, body.is-preload *:after {
-            -moz-animation: none !important;
-            -webkit-animation: none !important;
-            -ms-animation: none !important;
-            animation: none !important;
-            -moz-transition: none !important;
-            -webkit-transition: none !important;
-            -ms-transition: none !important;
-            transition: none !important;
-        }
+body.is-preload *, body.is-preload *:before, body.is-preload *:after {
+    -moz-animation: none !important;
+    -webkit-animation: none !important;
+    -ms-animation: none !important;
+    animation: none !important;
+    -moz-transition: none !important;
+    -webkit-transition: none !important;
+    -ms-transition: none !important;
+    transition: none !important;
+}
 
-    body, input, select, textarea {
-        color: #800000;
-        font-family: 'Source Sans Pro', sans-serif;
-        font-size: 15pt;
-        font-weight: 300 !important;
-        letter-spacing: -0.025em;
-        line-height: 1.75em;
-    }
+body, input, select, textarea {
+    color: #800000;
+    font-family: 'Source Sans Pro', sans-serif;
+    font-size: 15pt;
+    font-weight: 300 !important;
+    letter-spacing: -0.025em;
+    line-height: 1.75em;
+}
 
-    a {
-        -moz-transition: border-color 0.2s ease-in-out;
-        -webkit-transition: border-color 0.2s ease-in-out;
-        -ms-transition: border-color 0.2s ease-in-out;
-        transition: border-color 0.2s ease-in-out;
-        border-bottom: dotted 1px;
-        color: inherit;
-        outline: 0;
-        text-decoration: none;
-    }
+a {
+    -moz-transition: border-color 0.2s ease-in-out;
+    -webkit-transition: border-color 0.2s ease-in-out;
+    -ms-transition: border-color 0.2s ease-in-out;
+    transition: border-color 0.2s ease-in-out;
+    border-bottom: dotted 1px;
+    color: inherit;
+    outline: 0;
+    text-decoration: none;
+}
 
-        a:hover {
-            border-color: transparent;
-        }
+a:hover {
+    border-color: transparent;
+}
 
 /* Icon */
 
-    .icon {
-        text-decoration: none;
-        position: relative;
-    }
+.icon {
+    text-decoration: none;
+    position: relative;
+}
 
-        .icon:before {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            display: inline-block;
-            font-style: normal;
-            font-variant: normal;
-            text-rendering: auto;
-            line-height: 1;
-            text-transform: none !important;
-            font-family: 'Font Awesome 5 Pro';
-            font-weight: 400;
-        }
+.icon:before {
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    display: inline-block;
+    font-style: normal;
+    font-variant: normal;
+    text-rendering: auto;
+    line-height: 1;
+    text-transform: none !important;
+    font-family: 'Font Awesome 5 Pro';
+    font-weight: 400;
+}
 
-        .icon > .label {
-            display: none;
-        }
+.icon > .label {
+    display: none;
+}
 
-        .icon.solid:before {
-            font-weight: 900;
-        }
+.icon.solid:before {
+    font-weight: 900;
+}
 
-        .icon.brands:before {
-            font-family: 'Font Awesome 5 Brands';
-        }
+.icon.brands:before {
+    font-family: 'Font Awesome 5 Brands';
+}
 
 /* Wrapper */
 
-    @-moz-keyframes wrapper {
-        0% {
-            opacity: 0;
-        }
-
-        100% {
-            opacity: 1;
-        }
-    }
-
-    @-webkit-keyframes wrapper {
-        0% {
-            opacity: 0;
-        }
-
-        100% {
-            opacity: 1;
-        }
-    }
-
-    @-ms-keyframes wrapper {
-        0% {
-            opacity: 0;
-        }
-
-        100% {
-            opacity: 1;
-        }
-    }
-
-    @keyframes wrapper {
-        0% {
-            opacity: 0;
-        }
-
-        100% {
-            opacity: 1;
-        }
-    }
-
-    #wrapper {
-        -moz-animation: wrapper 1s forwards;
-        -webkit-animation: wrapper 1s forwards;
-        -ms-animation: wrapper 1s forwards;
-        animation: wrapper 1s forwards;
-        height: 100%;
-        left: 0;
+@-moz-keyframes wrapper {
+    0% {
         opacity: 0;
-        position: fixed;
-        top: 0;
-        width: 100%;
     }
+
+    100% {
+        opacity: 1;
+    }
+}
+
+@-webkit-keyframes wrapper {
+    0% {
+        opacity: 0;
+    }
+
+    100% {
+        opacity: 1;
+    }
+}
+
+@-ms-keyframes wrapper {
+    0% {
+        opacity: 0;
+    }
+
+    100% {
+        opacity: 1;
+    }
+}
+
+@keyframes wrapper {
+    0% {
+        opacity: 0;
+    }
+
+    100% {
+        opacity: 1;
+    }
+}
+
+#wrapper {
+    -moz-animation: wrapper 1s forwards;
+    -webkit-animation: wrapper 1s forwards;
+    -ms-animation: wrapper 1s forwards;
+    animation: wrapper 1s forwards;
+    height: 100%;
+    left: 0;
+    opacity: 0;
+    position: fixed;
+    top: 0;
+    width: 100%;
+}
 
 /* Main */
 
-    #main {
-        height: 100%;
-        left: 0;
-        position: fixed;
-        text-align: center;
-        top: 0;
-        width: 100%;
-    }
+#main {
+    height: 100%;
+    left: 0;
+    position: fixed;
+    text-align: center;
+    top: 0;
+    width: 100%;
+}
 
-        #main:before {
-            content: '';
-            display: inline-block;
-            height: 100%;
-            margin-right: 0;
-            vertical-align: middle;
-            width: 1px;
-        }
+#main:before {
+    content: '';
+    display: inline-block;
+    height: 100%;
+    margin-right: 0;
+    vertical-align: middle;
+    width: 1px;
+}
 
 /* Header */
 
-    @-moz-keyframes header {
-        0% {
-            -moz-transform: translate3d(0,1em,0);
-            -webkit-transform: translate3d(0,1em,0);
-            -ms-transform: translate3d(0,1em,0);
-            transform: translate3d(0,1em,0);
-            opacity: 0;
-        }
-
-        100% {
-            -moz-transform: translate3d(0,0,0);
-            -webkit-transform: translate3d(0,0,0);
-            -ms-transform: translate3d(0,0,0);
-            transform: translate3d(0,0,0);
-            opacity: 1;
-        }
+@-moz-keyframes header {
+    0% {
+        -moz-transform: translate3d(0,1em,0);
+        -webkit-transform: translate3d(0,1em,0);
+        -ms-transform: translate3d(0,1em,0);
+        transform: translate3d(0,1em,0);
+        opacity: 0;
     }
 
-    @-webkit-keyframes header {
-        0% {
-            -moz-transform: translate3d(0,1em,0);
-            -webkit-transform: translate3d(0,1em,0);
-            -ms-transform: translate3d(0,1em,0);
-            transform: translate3d(0,1em,0);
-            opacity: 0;
-        }
-
-        100% {
-            -moz-transform: translate3d(0,0,0);
-            -webkit-transform: translate3d(0,0,0);
-            -ms-transform: translate3d(0,0,0);
-            transform: translate3d(0,0,0);
-            opacity: 1;
-        }
-    }
-
-    @-ms-keyframes header {
-        0% {
-            -moz-transform: translate3d(0,1em,0);
-            -webkit-transform: translate3d(0,1em,0);
-            -ms-transform: translate3d(0,1em,0);
-            transform: translate3d(0,1em,0);
-            opacity: 0;
-        }
-
-        100% {
-            -moz-transform: translate3d(0,0,0);
-            -webkit-transform: translate3d(0,0,0);
-            -ms-transform: translate3d(0,0,0);
-            transform: translate3d(0,0,0);
-            opacity: 1;
-        }
-    }
-
-    @keyframes header {
-        0% {
-            -moz-transform: translate3d(0,1em,0);
-            -webkit-transform: translate3d(0,1em,0);
-            -ms-transform: translate3d(0,1em,0);
-            transform: translate3d(0,1em,0);
-            opacity: 0;
-        }
-
-        100% {
-            -moz-transform: translate3d(0,0,0);
-            -webkit-transform: translate3d(0,0,0);
-            -ms-transform: translate3d(0,0,0);
-            transform: translate3d(0,0,0);
-            opacity: 1;
-        }
-    }
-
-    @-moz-keyframes nav-icons {
-        0% {
-            -moz-transform: translate3d(0,1em,0);
-            -webkit-transform: translate3d(0,1em,0);
-            -ms-transform: translate3d(0,1em,0);
-            transform: translate3d(0,1em,0);
-            opacity: 0;
-        }
-
-        100% {
-            -moz-transform: translate3d(0,0,0);
-            -webkit-transform: translate3d(0,0,0);
-            -ms-transform: translate3d(0,0,0);
-            transform: translate3d(0,0,0);
-            opacity: 1;
-        }
-    }
-
-    @-webkit-keyframes nav-icons {
-        0% {
-            -moz-transform: translate3d(0,1em,0);
-            -webkit-transform: translate3d(0,1em,0);
-            -ms-transform: translate3d(0,1em,0);
-            transform: translate3d(0,1em,0);
-            opacity: 0;
-        }
-
-        100% {
-            -moz-transform: translate3d(0,0,0);
-            -webkit-transform: translate3d(0,0,0);
-            -ms-transform: translate3d(0,0,0);
-            transform: translate3d(0,0,0);
-            opacity: 1;
-        }
-    }
-
-    @-ms-keyframes nav-icons {
-        0% {
-            -moz-transform: translate3d(0,1em,0);
-            -webkit-transform: translate3d(0,1em,0);
-            -ms-transform: translate3d(0,1em,0);
-            transform: translate3d(0,1em,0);
-            opacity: 0;
-        }
-
-        100% {
-            -moz-transform: translate3d(0,0,0);
-            -webkit-transform: translate3d(0,0,0);
-            -ms-transform: translate3d(0,0,0);
-            transform: translate3d(0,0,0);
-            opacity: 1;
-        }
-    }
-
-    @keyframes nav-icons {
-        0% {
-            -moz-transform: translate3d(0,1em,0);
-            -webkit-transform: translate3d(0,1em,0);
-            -ms-transform: translate3d(0,1em,0);
-            transform: translate3d(0,1em,0);
-            opacity: 0;
-        }
-
-        100% {
-            -moz-transform: translate3d(0,0,0);
-            -webkit-transform: translate3d(0,0,0);
-            -ms-transform: translate3d(0,0,0);
-            transform: translate3d(0,0,0);
-            opacity: 1;
-        }
-    }
-
-    #header {
-        -moz-animation: header 1s 0.5s forwards;
-        -webkit-animation: header 1s 0.5s forwards;
-        -ms-animation: header 1s 0.5s forwards;
-        animation: header 1s 0.5s forwards;
-        -moz-backface-visibility: hidden;
-        -webkit-backface-visibility: hidden;
-        -ms-backface-visibility: hidden;
-        backface-visibility: hidden;
+    100% {
         -moz-transform: translate3d(0,0,0);
         -webkit-transform: translate3d(0,0,0);
         -ms-transform: translate3d(0,0,0);
         transform: translate3d(0,0,0);
-        cursor: default;
-        display: inline-block;
+        opacity: 1;
+    }
+}
+
+@-webkit-keyframes header {
+    0% {
+        -moz-transform: translate3d(0,1em,0);
+        -webkit-transform: translate3d(0,1em,0);
+        -ms-transform: translate3d(0,1em,0);
+        transform: translate3d(0,1em,0);
         opacity: 0;
-        position: relative;
-        text-align: center;
-        top: -1em;
-        vertical-align: middle;
-        width: 90%;
     }
 
-        #header h1 {
-            font-size: 4.35em;
-            font-weight: 900;
-            letter-spacing: -0.035em;
-            line-height: 1em;
-        }
+    100% {
+        -moz-transform: translate3d(0,0,0);
+        -webkit-transform: translate3d(0,0,0);
+        -ms-transform: translate3d(0,0,0);
+        transform: translate3d(0,0,0);
+        opacity: 1;
+    }
+}
 
-        #header p {
-            font-size: 1.75em;
-            font-weight: 600;
-            margin: 0.75em 0 0.25em 0;
-            opacity: 1;
-        }
+@-ms-keyframes header {
+    0% {
+        -moz-transform: translate3d(0,1em,0);
+        -webkit-transform: translate3d(0,1em,0);
+        -ms-transform: translate3d(0,1em,0);
+        transform: translate3d(0,1em,0);
+        opacity: 0;
+    }
 
-        #header nav {
-            margin: 1.5em 0 0 0;
-        }
+    100% {
+        -moz-transform: translate3d(0,0,0);
+        -webkit-transform: translate3d(0,0,0);
+        -ms-transform: translate3d(0,0,0);
+        transform: translate3d(0,0,0);
+        opacity: 1;
+    }
+}
 
-            #header nav li {
-                -moz-animation: nav-icons 0.5s ease-in-out forwards;
-                -webkit-animation: nav-icons 0.5s ease-in-out forwards;
-                -ms-animation: nav-icons 0.5s ease-in-out forwards;
-                animation: nav-icons 0.5s ease-in-out forwards;
-                -moz-backface-visibility: hidden;
-                -webkit-backface-visibility: hidden;
-                -ms-backface-visibility: hidden;
-                backface-visibility: hidden;
-                -moz-transform: translate3d(0,0,0);
-                -webkit-transform: translate3d(0,0,0);
-                -ms-transform: translate3d(0,0,0);
-                transform: translate3d(0,0,0);
-                display: inline-block;
-                height: 5.35em;
-                line-height: 5.885em;
-                opacity: 0;
-                position: relative;
-                top: 0;
-                width: 5.35em;
-            }
+@keyframes header {
+    0% {
+        -moz-transform: translate3d(0,1em,0);
+        -webkit-transform: translate3d(0,1em,0);
+        -ms-transform: translate3d(0,1em,0);
+        transform: translate3d(0,1em,0);
+        opacity: 0;
+    }
 
-                #header nav li:nth-child(1) {
-                    -moz-animation-delay: 1.2s;
-                    -webkit-animation-delay: 1.2s;
-                    -ms-animation-delay: 1.2s;
-                    animation-delay: 1.2s;
-                }
+    100% {
+        -moz-transform: translate3d(0,0,0);
+        -webkit-transform: translate3d(0,0,0);
+        -ms-transform: translate3d(0,0,0);
+        transform: translate3d(0,0,0);
+        opacity: 1;
+    }
+}
 
-                #header nav li:nth-child(2) {
-                    -moz-animation-delay: 1.45s;
-                    -webkit-animation-delay: 1.45s;
-                    -ms-animation-delay: 1.45s;
-                    animation-delay: 1.45s;
-                }
+@-moz-keyframes nav-icons {
+    0% {
+        -moz-transform: translate3d(0,1em,0);
+        -webkit-transform: translate3d(0,1em,0);
+        -ms-transform: translate3d(0,1em,0);
+        transform: translate3d(0,1em,0);
+        opacity: 0;
+    }
 
-                #header nav li:nth-child(3) {
-                    -moz-animation-delay: 1.7s;
-                    -webkit-animation-delay: 1.7s;
-                    -ms-animation-delay: 1.7s;
-                    animation-delay: 1.7s;
-                }
+    100% {
+        -moz-transform: translate3d(0,0,0);
+        -webkit-transform: translate3d(0,0,0);
+        -ms-transform: translate3d(0,0,0);
+        transform: translate3d(0,0,0);
+        opacity: 1;
+    }
+}
 
-                #header nav li:nth-child(4) {
-                    -moz-animation-delay: 1.95s;
-                    -webkit-animation-delay: 1.95s;
-                    -ms-animation-delay: 1.95s;
-                    animation-delay: 1.95s;
-                }
+@-webkit-keyframes nav-icons {
+    0% {
+        -moz-transform: translate3d(0,1em,0);
+        -webkit-transform: translate3d(0,1em,0);
+        -ms-transform: translate3d(0,1em,0);
+        transform: translate3d(0,1em,0);
+        opacity: 0;
+    }
 
-                #header nav li:nth-child(5) {
-                    -moz-animation-delay: 2.2s;
-                    -webkit-animation-delay: 2.2s;
-                    -ms-animation-delay: 2.2s;
-                    animation-delay: 2.2s;
-                }
+    100% {
+        -moz-transform: translate3d(0,0,0);
+        -webkit-transform: translate3d(0,0,0);
+        -ms-transform: translate3d(0,0,0);
+        transform: translate3d(0,0,0);
+        opacity: 1;
+    }
+}
 
-                #header nav li:nth-child(6) {
-                    -moz-animation-delay: 2.45s;
-                    -webkit-animation-delay: 2.45s;
-                    -ms-animation-delay: 2.45s;
-                    animation-delay: 2.45s;
-                }
+@-ms-keyframes nav-icons {
+    0% {
+        -moz-transform: translate3d(0,1em,0);
+        -webkit-transform: translate3d(0,1em,0);
+        -ms-transform: translate3d(0,1em,0);
+        transform: translate3d(0,1em,0);
+        opacity: 0;
+    }
 
-                #header nav li:nth-child(7) {
-                    -moz-animation-delay: 2.7s;
-                    -webkit-animation-delay: 2.7s;
-                    -ms-animation-delay: 2.7s;
-                    animation-delay: 2.7s;
-                }
+    100% {
+        -moz-transform: translate3d(0,0,0);
+        -webkit-transform: translate3d(0,0,0);
+        -ms-transform: translate3d(0,0,0);
+        transform: translate3d(0,0,0);
+        opacity: 1;
+    }
+}
 
-                #header nav li:nth-child(8) {
-                    -moz-animation-delay: 2.95s;
-                    -webkit-animation-delay: 2.95s;
-                    -ms-animation-delay: 2.95s;
-                    animation-delay: 2.95s;
-                }
+@keyframes nav-icons {
+    0% {
+        -moz-transform: translate3d(0,1em,0);
+        -webkit-transform: translate3d(0,1em,0);
+        -ms-transform: translate3d(0,1em,0);
+        transform: translate3d(0,1em,0);
+        opacity: 0;
+    }
 
-                #header nav li:nth-child(9) {
-                    -moz-animation-delay: 3.2s;
-                    -webkit-animation-delay: 3.2s;
-                    -ms-animation-delay: 3.2s;
-                    animation-delay: 3.2s;
-                }
+    100% {
+        -moz-transform: translate3d(0,0,0);
+        -webkit-transform: translate3d(0,0,0);
+        -ms-transform: translate3d(0,0,0);
+        transform: translate3d(0,0,0);
+        opacity: 1;
+    }
+}
 
-                #header nav li:nth-child(10) {
-                    -moz-animation-delay: 3.45s;
-                    -webkit-animation-delay: 3.45s;
-                    -ms-animation-delay: 3.45s;
-                    animation-delay: 3.45s;
-                }
+#header {
+    -moz-animation: header 1s 0.5s forwards;
+    -webkit-animation: header 1s 0.5s forwards;
+    -ms-animation: header 1s 0.5s forwards;
+    animation: header 1s 0.5s forwards;
+    -moz-backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
+    -ms-backface-visibility: hidden;
+    backface-visibility: hidden;
+    -moz-transform: translate3d(0,0,0);
+    -webkit-transform: translate3d(0,0,0);
+    -ms-transform: translate3d(0,0,0);
+    transform: translate3d(0,0,0);
+    cursor: default;
+    display: inline-block;
+    opacity: 0;
+    position: relative;
+    text-align: center;
+    top: -1em;
+    vertical-align: middle;
+    width: 90%;
+}
 
-            #header nav a {
-                -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-                -webkit-touch-callout: none;
-                border: 0;
-                display: inline-block;
-            }
+#header h1 {
+    font-size: 4.35em;
+    font-weight: 900;
+    letter-spacing: -0.035em;
+    line-height: 1em;
+}
 
-                #header nav a:before {
-                    -moz-transition: all 0.2s ease-in-out;
-                    -webkit-transition: all 0.2s ease-in-out;
-                    -ms-transition: all 0.2s ease-in-out;
-                    transition: all 0.2s ease-in-out;
-                    border-radius: 100%;
-                    border: solid 1px #800000;
-                    display: block;
-                    font-size: 1.75em;
-                    height: 2.5em;
-                    line-height: 2.5em;
-                    position: relative;
-                    text-align: center;
-                    top: 0;
-                    width: 2.5em;
-                }
+#header p {
+    font-size: 1.75em;
+    font-weight: 600;
+    margin: 0.75em 0 0.25em 0;
+    opacity: 1;
+}
 
-                #header nav a:hover {
-                    font-size: 1.1em;
-                }
+#header nav {
+    margin: 1.5em 0 0 0;
+}
 
-                    #header nav a:hover:before {
-                        background-color: rgba(255, 255, 255, 0.175);
-                        color: #800000;
-                    }
+#header nav li {
+    -moz-animation: nav-icons 0.5s ease-in-out forwards;
+    -webkit-animation: nav-icons 0.5s ease-in-out forwards;
+    -ms-animation: nav-icons 0.5s ease-in-out forwards;
+    animation: nav-icons 0.5s ease-in-out forwards;
+    -moz-backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
+    -ms-backface-visibility: hidden;
+    backface-visibility: hidden;
+    -moz-transform: translate3d(0,0,0);
+    -webkit-transform: translate3d(0,0,0);
+    -ms-transform: translate3d(0,0,0);
+    transform: translate3d(0,0,0);
+    display: inline-block;
+    height: 5.35em;
+    line-height: 5.885em;
+    opacity: 0;
+    position: relative;
+    top: 0;
+    width: 5.35em;
+}
 
-                #header nav a:active {
-                    font-size: 0.95em;
-                    background: none;
-                }
+#header nav li:nth-child(1) {
+    -moz-animation-delay: 1.2s;
+    -webkit-animation-delay: 1.2s;
+    -ms-animation-delay: 1.2s;
+    animation-delay: 1.2s;
+}
 
-                    #header nav a:active:before {
-                        background-color: rgba(255, 255, 255, 0.35);
-                        color: #800000;
-                    }
+#header nav li:nth-child(2) {
+    -moz-animation-delay: 1.45s;
+    -webkit-animation-delay: 1.45s;
+    -ms-animation-delay: 1.45s;
+    animation-delay: 1.45s;
+}
 
-                #header nav a span {
-                    display: none;
-                }
+#header nav li:nth-child(3) {
+    -moz-animation-delay: 1.7s;
+    -webkit-animation-delay: 1.7s;
+    -ms-animation-delay: 1.7s;
+    animation-delay: 1.7s;
+}
+
+#header nav li:nth-child(4) {
+    -moz-animation-delay: 1.95s;
+    -webkit-animation-delay: 1.95s;
+    -ms-animation-delay: 1.95s;
+    animation-delay: 1.95s;
+}
+
+#header nav li:nth-child(5) {
+    -moz-animation-delay: 2.2s;
+    -webkit-animation-delay: 2.2s;
+    -ms-animation-delay: 2.2s;
+    animation-delay: 2.2s;
+}
+
+#header nav li:nth-child(6) {
+    -moz-animation-delay: 2.45s;
+    -webkit-animation-delay: 2.45s;
+    -ms-animation-delay: 2.45s;
+    animation-delay: 2.45s;
+}
+
+#header nav li:nth-child(7) {
+    -moz-animation-delay: 2.7s;
+    -webkit-animation-delay: 2.7s;
+    -ms-animation-delay: 2.7s;
+    animation-delay: 2.7s;
+}
+
+#header nav li:nth-child(8) {
+    -moz-animation-delay: 2.95s;
+    -webkit-animation-delay: 2.95s;
+    -ms-animation-delay: 2.95s;
+    animation-delay: 2.95s;
+}
+
+#header nav li:nth-child(9) {
+    -moz-animation-delay: 3.2s;
+    -webkit-animation-delay: 3.2s;
+    -ms-animation-delay: 3.2s;
+    animation-delay: 3.2s;
+}
+
+#header nav li:nth-child(10) {
+    -moz-animation-delay: 3.45s;
+    -webkit-animation-delay: 3.45s;
+    -ms-animation-delay: 3.45s;
+    animation-delay: 3.45s;
+}
+
+#header nav a {
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    -webkit-touch-callout: none;
+    border: 0;
+    display: inline-block;
+}
+
+#header nav a:before {
+    -moz-transition: all 0.2s ease-in-out;
+    -webkit-transition: all 0.2s ease-in-out;
+    -ms-transition: all 0.2s ease-in-out;
+    transition: all 0.2s ease-in-out;
+    border-radius: 100%;
+    border: solid 1px #800000;
+    display: block;
+    font-size: 1.75em;
+    height: 2.5em;
+    line-height: 2.5em;
+    position: relative;
+    text-align: center;
+    top: 0;
+    width: 2.5em;
+}
+
+#header nav a:hover {
+    font-size: 1.1em;
+}
+
+#header nav a:hover:before {
+    background-color: rgba(255, 255, 255, 0.175);
+    color: #800000;
+}
+
+#header nav a:active {
+    font-size: 0.95em;
+    background: none;
+}
+
+#header nav a:active:before {
+    background-color: rgba(255, 255, 255, 0.35);
+    color: #800000;
+}
+
+#header nav a span {
+    display: none;
+}
 
 /* Footer */
 
-    #footer {
-        bottom: 0;
-        cursor: default;
-        height: 3em;
-        left: 0;
-        line-height: 3em;
-        position: absolute;
-        text-align: center;
-        width: 100%;
-    }
+#footer {
+    bottom: 0;
+    cursor: default;
+    height: 3em;
+    left: 0;
+    line-height: 3em;
+    position: absolute;
+    text-align: center;
+    width: 100%;
+}
 
 /* Wide */
 
-    @media screen and (max-width: 1680px) {
+@media screen and (max-width: 1680px) {
 
-        /* Basic */
+    /* Basic */
 
-            body, input, select, textarea {
-                font-size: 13pt;
-            } }
+    body, input, select, textarea {
+        font-size: 13pt;
+    } }
 
 /* Normal */
 
-    @media screen and (max-width: 1280px) {
+@media screen and (max-width: 1280px) {
 
-        /* Basic */
+    /* Basic */
 
-            body, input, select, textarea {
-                font-size: 12pt;
-            } }
+    body, input, select, textarea {
+        font-size: 12pt;
+    } }
 
 /* Mobile */
 
-    @media screen and (max-width: 736px) {
+@media screen and (max-width: 736px) {
 
-        /* Basic */
+    /* Basic */
 
-            body {
-                min-width: 320px;
-            }
+    body {
+        min-width: 320px;
+    }
 
-            body, input, select, textarea {
-                font-size: 11pt;
-            }
+    body, input, select, textarea {
+        font-size: 11pt;
+    }
 
     /* Header */
 
-        #header h1 {
-            font-size: 2.5em;
-        }
+    #header h1 {
+        font-size: 2.5em;
+    }
 
-        #header p {
-            font-size: 1em;
-        }
+    #header p {
+        font-size: 1em;
+    }
 
-        #header nav {
-            font-size: 1em;
-        }
+    #header nav {
+        font-size: 1em;
+    }
 
-            #header nav a:hover {
-                font-size: 1em;
-            }
+    #header nav a:hover {
+        font-size: 1em;
+    }
 
-            #header nav a:active {
-                font-size: 1em;
-            } }
+    #header nav a:active {
+        font-size: 1em;
+    } }
 
 /* Mobile (Portrait) */
 
-    @media screen and (max-width: 480px) {
+@media screen and (max-width: 480px) {
 
-        /* Basic */
+    /* Basic */
 
-            body, input, select, textarea {
-                font-size: 10pt;
-            }
+    body, input, select, textarea {
+        font-size: 10pt;
+    }
 
     /* Header */
 
-        #header nav {
-            padding: 0 1em;
-        } }
+    #header nav {
+        padding: 0 1em;
+    } }

--- a/assets/css/noscript.css
+++ b/assets/css/noscript.css
@@ -1,15 +1,15 @@
 /* Wrapper */
 
-	#wrapper {
-		opacity: 1 !important;
-	}
+#wrapper {
+    opacity: 1 !important;
+}
 
 /* Header */
 
-	#header {
-		opacity: 1 !important;
-	}
+#header {
+    opacity: 1 !important;
+}
 
-		#header nav li {
-			opacity: 1 !important;
-		}
+#header nav li {
+    opacity: 1 !important;
+}

--- a/assets/css/tooltip.css
+++ b/assets/css/tooltip.css
@@ -1,0 +1,185 @@
+*[data-tooltip] {
+    position: relative;
+    z-index: 99;
+}
+
+*[data-tooltip-mask] {
+    z-index: 999;
+    box-shadow: inset 0 0 0 500px rgba(254, 224, 224, 0), 0 0 0 5000px rgba(254, 224, 224, 0);
+    transition: all 500ms 100ms;
+}
+
+*[data-tooltip-mask]:hover {
+    box-shadow: inset 0 0 0 500px rgba(254, 224, 224, 0.40), 0 0 0 5000px rgba(254, 224, 224, 0.40);
+}
+
+*[data-tooltip]:hover:before,
+*[data-tooltip]:hover:after {
+    visibility: visible;
+    opacity: 1;
+}
+
+*[data-tooltip]:before {
+    visibility: hidden;
+    opacity: 0;
+    transition: all 300ms 000ms cubic-bezier(0.25, 0, 0.15, 1.50);
+}
+
+*[data-tooltip]:hover:before {
+    transition: all 300ms 200ms cubic-bezier(0.25, 0, 0.15, 1.50);
+}
+
+*[data-tooltip]:after {
+    visibility: hidden;
+    opacity: 0;
+    content: attr(data-tooltip);
+    line-height: 1.5em;
+    position: absolute;
+    z-index: 99;
+    padding: 15px 20px;
+    background: #333;
+    color: #fff;
+    font-size: 12pt;
+    border-radius: 5px;
+    width: 180%;
+    max-width: 200px;
+    transition: all 300ms 100ms cubic-bezier(0.25, 0, 0.15, 1.50);
+}
+
+/* BOTTOM TOOLTIP */
+
+*[data-tooltip]:before,
+*[data-tooltip-bottom]:before {
+    content: "";
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 0 12.5px 15px 12.5px;
+    border-color: transparent transparent #333 transparent;
+    position: absolute;
+    left: 0;
+    right: 0;
+    margin: auto;
+    bottom: -25px;
+}
+
+*[data-tooltip]:hover:before,
+*[data-tooltip-bottom]:hover:before {
+    bottom: -15px;
+}
+
+*[data-tooltip]:after,
+*[data-tooltip-bottom]:after {
+    transform: translate(-50%, 100%) scale(.8);
+    left: 50%;
+    bottom: -10px;
+}
+
+*[data-tooltip]:hover:after,
+*[data-tooltip-bottom]:hover:after {
+    transform: translate(-50%, 100%) scale(1);
+}
+
+/* TOP TOOLTIP */
+
+*[data-tooltip-top]:before {
+    content: "";
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 15px 12.5px 0 12.5px;
+    border-color: #333 transparent transparent transparent;
+    position: absolute;
+    left: 0;
+    right: 0;
+    margin: auto;
+    bottom: inherit;
+    top: -25px;
+}
+
+*[data-tooltip-top]:hover:before {
+    bottom: inherit;
+    top: -15px;
+}
+
+*[data-tooltip-top]:after {
+    transform: translate(-50%, -100%) scale(.8);
+    left: 50%;
+    top: -10px;
+    bottom: inherit;
+}
+
+*[data-tooltip-top]:hover:after {
+    transform: translate(-50%, -100%) scale(1);
+}
+
+/* LEFT TOOLTIP */
+
+*[data-tooltip-left]:before {
+    content: "";
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 12.5px 0 12.5px 15px;
+    border-color: transparent transparent transparent #333;
+    position: absolute;
+    margin: auto;
+    bottom: 0;
+    top: 0;
+    right: inherit;
+    left: -25px;
+}
+
+*[data-tooltip-left]:hover:before {
+    bottom: 0;
+    top: 0;
+    right: inherit;
+    left: -15px;
+}
+
+*[data-tooltip-left]:after {
+    transform: translate(-100%, -50%) scale(.8);
+    left: -10px;
+    top: 50%;
+    bottom: inherit;
+}
+
+*[data-tooltip-left]:hover:after {
+    transform: translate(-100%, -50%) scale(1);
+}
+
+/* RIGHT TOOLTIP */
+
+*[data-tooltip-right]:before {
+    content: "";
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 12.5px 15px 12.5px 0;
+    border-color: transparent #333 transparent transparent;
+    position: absolute;
+    margin: auto;
+    bottom: 0;
+    top: 0;
+    left: inherit;
+    right: -25px;
+}
+
+*[data-tooltip-right]:hover:before {
+    bottom: 0;
+    top: 0;
+    left: inherit;
+    right: -15px;
+}
+
+*[data-tooltip-right]:after {
+    transform: translate(100%, -50%) scale(.8);
+    right: -10px;
+    top: 50%;
+    left: inherit;
+    bottom: inherit;
+}
+
+*[data-tooltip-right]:hover:after {
+    transform: translate(100%, -50%) scale(1);
+}

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
         <meta name="theme-color" content="#ffffff">
 
         <link rel="stylesheet" href="assets/css/main.css">
+        <link rel="stylesheet" href="assets/css/tooltip.css">
         <noscript><link rel="stylesheet" href="assets/css/noscript.css"></noscript>
 
     </head>
@@ -73,11 +74,11 @@
                     <p>Discover SUTD, your way!</p>
                     <nav>
                         <ul>
-                            <li><a href="https://discover.opensutd.org/guide.html" class="icon solid fa-book"><span class="label">Guide</span></a></li>
-                            <li><a href="https://discover.opensutd.org/calendar.html" class="icon solid fa-calendar-alt"><span class="label">Calendar</span></a></li>
-                            <li><a href="https://discover.opensutd.org/events.html" class="icon solid fa-glass-cheers"><span class="label">Events</span></a></li>
-                            <li><a href="https://discover.opensutd.org/people.html" class="icon solid fa-users"><span class="label">People</span></a></li>
-                            <li><a href="https://discover.opensutd.org/supper.html" class="icon solid fa-utensils"><span class="label">Supper</span></a></li>
+                            <li data-tooltip-top data-tooltip-mask data-tooltip="Take a look at our guide here!"><a href="https://discover.opensutd.org/guide.html" class="icon solid fa-book"><span class="label">Guide</span></a></li>
+                            <li data-tooltip-top data-tooltip-mask data-tooltip="View our event calendar here!"><a href="https://discover.opensutd.org/calendar.html" class="icon solid fa-calendar-alt"><span class="label">Calendar</span></a></li>
+                            <li data-tooltip-top data-tooltip-mask data-tooltip="Explore all the various events here!"><a href="https://discover.opensutd.org/events.html" class="icon solid fa-glass-cheers"><span class="label">Events</span></a></li>
+                            <li data-tooltip-top data-tooltip-mask data-tooltip="Browse through the book list of Human Library here!"><a href="https://discover.opensutd.org/people.html" class="icon solid fa-users"><span class="label">People</span></a></li>
+                            <li data-tooltip-top data-tooltip-mask data-tooltip="Check our free supper schedule here!"><a href="https://discover.opensutd.org/supper.html" class="icon solid fa-utensils"><span class="label">Supper</span></a></li>
                         </ul>
                     </nav>
                 </header>


### PR DESCRIPTION
Fixes:
- Typos in spelling, URL and name
- Convert indentations of `main.css` from tabs to spaces
- Standardise indentations of CSS files
- Minor footer `line-height` change

Features:
- Tooltip when hovering on `nav-icons`